### PR TITLE
Fix installation step in ReadMe 📝

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ composer require keepsuit/laravel-temporal
 You can publish the config file with:
 
 ```bash
-php artisan vendor:publish --tag="laravel-temporal-config"
+php artisan vendor:publish --tag="temporal-config"
 ```
 
 This is the contents of the published config file:


### PR DESCRIPTION
When installing the package, I received the message:

```php
No publishable resources for tag [laravel-temporal-config].
```

This PR fixes `publish configuration` step in ReadMe.