### PR TITLE
Add interface for `Temporal` class 🔧

### DIFF
--- a/src/Contracts/TemporalInterface.php
+++ b/src/Contracts/TemporalInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keepsuit\LaravelTemporal\Contracts;
+
+interface TemporalInterface
+{
+    public function newActivity();
+    public function newLocalActivity();
+    public function newWorkflow();
+    public function newChildWorkflow();
+}

--- a/src/Temporal.php
+++ b/src/Temporal.php
@@ -6,8 +6,9 @@ use Keepsuit\LaravelTemporal\Builder\ActivityBuilder;
 use Keepsuit\LaravelTemporal\Builder\ChildWorkflowBuilder;
 use Keepsuit\LaravelTemporal\Builder\LocalActivityBuilder;
 use Keepsuit\LaravelTemporal\Builder\WorkflowBuilder;
+use Keepsuit\LaravelTemporal\Contracts\TemporalInterface;
 
-class Temporal
+class Temporal implements TemporalInterface
 {
     public function newActivity(): ActivityBuilder
     {


### PR DESCRIPTION
Hi @cappuc!

To be able to use dependency injection instead of facade and test classes in isolation we need an interface for the main `Temporal` class.

I haven't added types for those methods since all of them return concrete classes and that would have been a BC break.
