### PR TITLE
Temporal root namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,16 @@ the [official documentation](https://docs.temporal.io/application-development/?l
 ### Create workflows and activities
 
 To create a new workflow, you can use the `make:workflow {name}` command, which will create a new workflow interface & relative class in
-the `app/Workflows` directory.
+the `app/Temporal/Workflows` directory.
 
 To create a new activity, you can use the `make:activity {name}` command, which will create a new activity interface & relative class in
-the `app/Activities` directory.
+the `app/Temporal/Activities` directory.
 
-Workflows in `app/Workflows` and activities in `app/Activities` and `app/Workflows` are automatically registered.
+> [!NOTE]
+> If you already have workflow/activities in `app/Workflows` and `app/Activities` directories,
+> the make commands will create the new workflow/activity in the these directories.
+
+Workflows in `app/Temporal/Workflows` and `app/Workflows` and activities in `app/Temporal/Activities`, `app/Activities`, `app/Temporal/Workflows` and `app/Workflows` are automatically registered.
 If you put your workflows and activities in other directories, you can register them manually in the `workflows` and `activities` config keys.
 
 ### Build and start a workflow

--- a/src/Commands/ActivityMakeCommand.php
+++ b/src/Commands/ActivityMakeCommand.php
@@ -29,6 +29,12 @@ class ActivityMakeCommand extends GeneratorCommand
 
     protected function getDefaultNamespace($rootNamespace): string
     {
+        $rootNamespace = match (true) {
+            is_dir($this->laravel->path('Temporal/Activities')) => $rootNamespace.'\\Temporal',
+            ! is_dir($this->laravel->path('Activities')) => $rootNamespace.'\\Temporal',
+            default => $rootNamespace
+        };
+
         if ($this->option('for-workflow') !== null) {
             $namespace = Str::of($this->option('for-workflow'))
                 ->whenEndsWith('Workflow', fn ($name) => $name->replaceLast('Workflow', ''));

--- a/src/Commands/WorkflowMakeCommand.php
+++ b/src/Commands/WorkflowMakeCommand.php
@@ -4,6 +4,7 @@ namespace Keepsuit\LaravelTemporal\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
+use Keepsuit\LaravelTemporal\Support\DiscoverWorkflows;
 
 class WorkflowMakeCommand extends GeneratorCommand
 {
@@ -25,6 +26,12 @@ class WorkflowMakeCommand extends GeneratorCommand
 
     protected function getDefaultNamespace($rootNamespace): string
     {
+        $rootNamespace = match (true) {
+            is_dir($this->laravel->path('Temporal/Workflows')) => $rootNamespace.'\\Temporal',
+            ! is_dir($this->laravel->path('Workflows')) => $rootNamespace.'\\Temporal',
+            default => $rootNamespace
+        };
+
         if ($this->option('scoped')) {
             $namespace = Str::of($this->getNameInput())
                 ->when($this->option('interface'), fn ($name) => $name->replaceLast('Interface', ''))

--- a/src/Commands/WorkflowMakeCommand.php
+++ b/src/Commands/WorkflowMakeCommand.php
@@ -4,7 +4,6 @@ namespace Keepsuit\LaravelTemporal\Commands;
 
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
-use Keepsuit\LaravelTemporal\Support\DiscoverWorkflows;
 
 class WorkflowMakeCommand extends GeneratorCommand
 {

--- a/src/Support/DiscoverActivities.php
+++ b/src/Support/DiscoverActivities.php
@@ -11,7 +11,7 @@ class DiscoverActivities
     /**
      * Get all of the workflows by searching the given workflow directory.
      */
-    public static function within(string $activitiesPath, string $basePath): array
+    public static function within(string $activitiesPath): array
     {
         /** @var Collection<class-string,class-string|null> $activities */
         $activities = Collection::make();

--- a/src/Support/DiscoverWorkflows.php
+++ b/src/Support/DiscoverWorkflows.php
@@ -11,7 +11,7 @@ class DiscoverWorkflows
     /**
      * Get all of the workflows by searching the given workflow directory.
      */
-    public static function within(string $workflowPath, string $basePath): array
+    public static function within(string $workflowPath): array
     {
         /** @var Collection<class-string,class-string|null> $workflows */
         $workflows = Collection::make([]);

--- a/src/TemporalDiscovery.php
+++ b/src/TemporalDiscovery.php
@@ -18,13 +18,14 @@ class TemporalDiscovery
      */
     protected function discoverWorkflows(): Collection
     {
-        return Collection::make([
+        $paths = [
             $this->app->path('Workflows'),
-        ])
+            $this->app->path('Temporal/Workflows'),
+        ];
+
+        return Collection::make($paths)
             ->reject(fn ($directory) => ! is_dir($directory))
-            ->reduce(fn (Collection $discovered, string $directory) => $discovered->mergeRecursive(
-                DiscoverWorkflows::within($directory, base_path())
-            ), Collection::make());
+            ->reduce(fn (Collection $discovered, string $directory) => $discovered->mergeRecursive(DiscoverWorkflows::within($directory)), Collection::make());
     }
 
     /**
@@ -32,14 +33,16 @@ class TemporalDiscovery
      */
     protected function discoverActivities(): Collection
     {
-        return Collection::make([
+        $paths = [
             $this->app->path('Workflows'),
             $this->app->path('Activities'),
-        ])
+            $this->app->path('Temporal/Activities'),
+            $this->app->path('Temporal/Workflows'),
+        ];
+
+        return Collection::make($paths)
             ->reject(fn ($directory) => ! is_dir($directory))
-            ->reduce(fn (Collection $discovered, string $directory) => $discovered->mergeRecursive(
-                DiscoverActivities::within($directory, base_path())
-            ), Collection::make());
+            ->reduce(fn (Collection $discovered, string $directory) => $discovered->mergeRecursive(DiscoverActivities::within($directory)), Collection::make());
     }
 
     /**

--- a/tests/Unit/Discovery/ActivityDiscoveryTest.php
+++ b/tests/Unit/Discovery/ActivityDiscoveryTest.php
@@ -14,7 +14,6 @@ it('can discovery activities', function () {
 
     $activities = DiscoverActivities::within(
         __DIR__.'/../../Fixtures/WorkflowDiscovery/Activities',
-        getcwd()
     );
 
     expect($activities)->toBe([

--- a/tests/Unit/Discovery/WorkflowDiscoveryTest.php
+++ b/tests/Unit/Discovery/WorkflowDiscoveryTest.php
@@ -14,7 +14,6 @@ it('can discovery workflows', function () {
 
     $workflows = DiscoverWorkflows::within(
         __DIR__.'/../../Fixtures/WorkflowDiscovery/Workflows',
-        getcwd()
     );
 
     expect($workflows)->toBe([


### PR DESCRIPTION
Fixes #16 

* Auto-discover Workflows and Activities in the new namespaces: `Temporal\Workflows` and `Temporal\Activities`
* Detect which namespace is used in make commands 