### PR TITLE
Support for namespaces config when starting child workflows and activities.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $workflow = Temporal::newWorkflow()
 $result = $workflow->yourMethod();
 
 // This will start a new workflow execution and return immediately
-app(\Temporal\Client\WorkflowClient::class)->start($workflow);
+app(\Temporal\Client\WorkflowClientInterface::class)->start($workflow);
 ```
 
 ### Build and start an activity

--- a/src/Builder/ActivityBuilder.php
+++ b/src/Builder/ActivityBuilder.php
@@ -29,6 +29,7 @@ class ActivityBuilder
     public function __construct()
     {
         $this->activityOptions = ActivityOptions::new()
+            ->withNamespace(config('temporal.namespace'))
             ->withTaskQueue(config('temporal.queue'))
             ->withRetryOptions($this->getDefaultRetryOptions(config('temporal.retry.activity')));
     }

--- a/src/Builder/ChildWorkflowBuilder.php
+++ b/src/Builder/ChildWorkflowBuilder.php
@@ -34,6 +34,7 @@ class ChildWorkflowBuilder
     public function __construct()
     {
         $this->workflowOptions = ChildWorkflowOptions::new()
+            ->withNamespace(config('temporal.namespace'))
             ->withTaskQueue(config('temporal.queue'))
             ->withRetryOptions($this->getDefaultRetryOptions(config('temporal.retry.workflow')));
     }


### PR DESCRIPTION
If the application works on a specific namespace the child workflows and activities will go back to 'default'