### PR TITLE
Updated eloquent model serialization

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,19 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Keepsuit\\\\LaravelTemporal\\\\Contracts\\\\TemporalSerializable\\:\\:fromTemporalPayload\\(\\) has no return type specified\\.$#"
+			message: '#^Method Keepsuit\\LaravelTemporal\\Contracts\\TemporalSerializable\:\:fromTemporalPayload\(\) has no return type specified\.$#'
+			identifier: missingType.return
 			count: 1
 			path: src/Contracts/TemporalSerializable.php
+
+		-
+			message: '#^Unable to resolve the template type TMakeKey in call to method static method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:make\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: src/Integrations/Eloquent/TemporalEloquentSerializer.php
+
+		-
+			message: '#^Unable to resolve the template type TMakeValue in call to method static method Illuminate\\Support\\Collection\<\(int\|string\),mixed\>\:\:make\(\)$#'
+			identifier: argument.templateType
+			count: 1
+			path: src/Integrations/Eloquent/TemporalEloquentSerializer.php

--- a/rector.php
+++ b/rector.php
@@ -6,6 +6,7 @@ use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\PropertyProperty\RemoveNullPropertyInitializationRector;
 use Rector\Php70\Rector\StmtsAwareInterface\IfIssetToCoalescingRector;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 use Rector\Php80\Rector\ClassMethod\AddParamBasedOnParentClassMethodRector;
 use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
 use Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector;
@@ -28,6 +29,7 @@ return RectorConfig::configure()
     ->withSkip([
         AddArrowFunctionReturnTypeRector::class,
         AddParamBasedOnParentClassMethodRector::class,
+        ClosureToArrowFunctionRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
         IfIssetToCoalescingRector::class,
         RemoveNullPropertyInitializationRector::class,

--- a/src/DataConverter/LaravelPayloadConverter.php
+++ b/src/DataConverter/LaravelPayloadConverter.php
@@ -4,6 +4,7 @@ namespace Keepsuit\LaravelTemporal\DataConverter;
 
 use Illuminate\Database\Eloquent\Model;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
+use Keepsuit\LaravelTemporal\Integrations\Eloquent\TemporalEloquentSerializer;
 use ReflectionClass;
 use Spatie\LaravelData\Data;
 use Temporal\Api\Common\V1\Payload;
@@ -29,7 +30,7 @@ class LaravelPayloadConverter extends JsonConverter
         }
 
         if ($value instanceof Model) {
-            return $this->create($value->toJson(self::JSON_FLAGS));
+            return $this->create(\Safe\json_encode(TemporalEloquentSerializer::toPayload($value), self::JSON_FLAGS));
         }
 
         return parent::toPayload($value);
@@ -72,7 +73,8 @@ class LaravelPayloadConverter extends JsonConverter
         }
 
         if ($reflection->isSubclassOf(Model::class)) {
-            return $reflection->newInstance($data);
+            /** @var class-string<Model> $class */
+            return TemporalEloquentSerializer::fromPayload($class, $data);
         }
 
         return parent::fromPayload($payload, $type);

--- a/src/Integrations/Eloquent/TemporalEloquentSerialize.php
+++ b/src/Integrations/Eloquent/TemporalEloquentSerialize.php
@@ -2,149 +2,24 @@
 
 namespace Keepsuit\LaravelTemporal\Integrations\Eloquent;
 
-use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Database\Eloquent\Relations\HasOne;
-use Illuminate\Database\Eloquent\Relations\Relation;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 
 /**
+ * @deprecated Eloquent model are now handled without this trait.
+ * If you want to use default Eloquent serialization, remove this trait and TemporalSerializable interface from your models.
+ *
  * @mixin Model
  */
 trait TemporalEloquentSerialize
 {
-    protected function mapAttributeKeyToTemporal(string $attribute): string
-    {
-        return match (config('temporal.integrations.eloquent.serialize_attribute_case')) {
-            'snake' => Str::snake($attribute),
-            'camel' => Str::camel($attribute),
-            default => $attribute,
-        };
-    }
-
-    protected function mapAttributeKeyFromTemporal(string $attribute): string
-    {
-        return match (config('temporal.integrations.eloquent.deserialize_attribute_case')) {
-            'snake' => Str::snake($attribute),
-            'camel' => Str::camel($attribute),
-            default => $attribute,
-        };
-    }
-
     public function toTemporalPayload(): array
     {
-        $relations = Collection::make($this->getArrayableRelations())
-            ->mapWithKeys(function (mixed $value, string $key): array {
-                $key = static::$snakeAttributes ? Str::snake($key) : $key;
-
-                return [
-                    $key => match (true) {
-                        $value instanceof TemporalSerializable => $value->toTemporalPayload(),
-                        $value instanceof Arrayable => $value->toArray(),
-                        default => $value,
-                    },
-                ];
-            });
-
-        return Collection::make($this->attributesToArray())
-            ->merge($relations)
-            ->mapWithKeys(fn (mixed $value, string $key) => [$this->mapAttributeKeyToTemporal($key) => $value])
-            ->when(config('temporal.integrations.eloquent.include_metadata_field', false), fn (Collection $collection) => $collection
-                ->put('__exists', $this->exists)
-                ->put('__dirty', $this->isDirty())
-            )
-            ->all();
+        return TemporalEloquentSerializer::toPayload($this);
     }
 
     public static function fromTemporalPayload(array $payload): static
     {
-        $reflectionClass = new \ReflectionClass(static::class);
-
-        /** @var Collection<array-key,string> $attributes */
-        $relations = collect($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC))
-            ->filter(function (\ReflectionMethod $reflectionMethod): bool {
-                $returnType = $reflectionMethod->getReturnType();
-
-                return $returnType instanceof \ReflectionNamedType
-                    && is_subclass_of($returnType->getName(), Relation::class);
-            })
-            ->map(fn (\ReflectionMethod $reflectionMethod) => $reflectionMethod->getName())
-            ->values();
-
-        $model = new static;
-
-        /** @var Collection $attributes */
-        $attributes = Collection::make($payload)
-            ->mapWithKeys(fn (mixed $value, string $key) => [$model->mapAttributeKeyFromTemporal($key) => $value]);
-
-        /** @var bool $exists */
-        $exists = $attributes->get('__exists', $attributes->get($model->getKeyName()) !== null);
-
-        /** @var bool $dirty */
-        $dirty = $attributes->get('__dirty', true);
-
-        $instance = $model->newInstance([], $exists);
-
-        $instance->forceFill($attributes->except($relations->merge(['__exists', '__dirty']))->all());
-
-        if (! $dirty) {
-            $instance->syncOriginal();
-        }
-
-        foreach ($relations as $relationName) {
-            $relation = $model->{$relationName}();
-
-            if (! ($relation instanceof Relation)) {
-                continue;
-            }
-
-            $relatedModel = $relation->getRelated();
-
-            if ($relation instanceof BelongsTo || $relation instanceof HasOne) {
-                $instance->setRelation($relationName, self::buildRelatedInstance($relatedModel, $attributes->get($relationName)));
-
-                continue;
-            }
-
-            $instance->setRelation($relationName, $relatedModel->newCollection(
-                Collection::make($attributes->get($relationName))
-                    ->map(fn (array $data) => static::buildRelatedInstance($relatedModel, $data))
-                    ->filter()
-                    ->all()
-            ));
-        }
-
-        return $instance;
-    }
-
-    private static function buildRelatedInstance(Model $relatedModel, ?array $attributes): ?Model
-    {
-        if ($attributes === null) {
-            return null;
-        }
-
-        if ($relatedModel instanceof TemporalSerializable) {
-            return $relatedModel::fromTemporalPayload($attributes);
-        }
-
-        /** @var bool $exists */
-        $exists = Arr::get($attributes, '__exists', Arr::get($attributes, $relatedModel->getKeyName()) !== null);
-
-        /** @var bool $dirty */
-        $dirty = Arr::get($attributes, '__dirty', true);
-
-        $relatedModelInstance = $relatedModel->newInstance([], $exists);
-
-        $relatedModelInstance->forceFill(Arr::except($attributes, ['__exists', '__dirty']));
-
-        if ($dirty) {
-            $relatedModelInstance->syncOriginal();
-        }
-
-        return $relatedModelInstance;
+        return TemporalEloquentSerializer::fromPayload(static::class, $payload);
     }
 }

--- a/src/Integrations/Eloquent/TemporalEloquentSerializer.php
+++ b/src/Integrations/Eloquent/TemporalEloquentSerializer.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Keepsuit\LaravelTemporal\Integrations\Eloquent;
+
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
+
+class TemporalEloquentSerializer
+{
+    /**
+     * @var array<string, string[]>
+     */
+    protected static array $modelsRelationsMap = [];
+
+    public static function toPayload(Model $model): array
+    {
+        $relations = Collection::make($model->getRelations())
+            ->mapWithKeys(function (EloquentCollection|Model $value, string $key): array {
+                return [
+                    $key => match (true) {
+                        $value instanceof TemporalSerializable => $value->toTemporalPayload(),
+                        $value instanceof Model => static::toPayload($value),
+                        $value instanceof EloquentCollection => $value->map(fn (Model $related) => match (true) {
+                            $related instanceof TemporalSerializable => $related->toTemporalPayload(),
+                            default => static::toPayload($related),
+                        }),
+                    },
+                ];
+            });
+
+        return Collection::make($model->attributesToArray())
+            ->merge($relations)
+            ->mapWithKeys(fn (mixed $value, string $key) => [static::mapAttributeKeyToTemporal($key) => $value])
+            ->when(static::shouldIncludeMetadataFields(), fn (Collection $collection) => $collection
+                ->put('__exists', $model->exists)
+                ->put('__dirty', $model->isDirty())
+            )
+            ->all();
+    }
+
+    /**
+     * @param  class-string<Model>  $className
+     */
+    public static function fromPayload(string $className, array $payload): Model
+    {
+        $model = new $className;
+
+        $relations = static::getModelRelationMethods($model);
+
+        /** @var Collection<string,mixed> $attributes */
+        $attributes = Collection::make($payload)
+            ->mapWithKeys(fn (mixed $value, string $key) => [static::mapAttributeKeyFromTemporal($key) => $value]);
+
+        /** @var bool $exists */
+        $exists = $attributes->get('__exists', $attributes->get($model->getKeyName()) !== null);
+
+        /** @var bool $dirty */
+        $dirty = $attributes->get('__dirty', true);
+
+        $instance = $model->newInstance([], $exists);
+
+        $instance->forceFill($attributes->except($relations)->except(['__exists', '__dirty'])->all());
+
+        if (! $dirty) {
+            $instance->syncOriginal();
+        }
+
+        foreach ($relations as $relationName) {
+            if (! $attributes->has($relationName)) {
+                continue;
+            }
+
+            $relation = $model->{$relationName}();
+
+            if (! ($relation instanceof Relation)) {
+                continue;
+            }
+
+            $relatedModel = $relation->getRelated();
+
+            if ($relation instanceof BelongsTo || $relation instanceof HasOne || $relation instanceof MorphOne) {
+                $instance->setRelation(
+                    $relationName,
+                    static::fromPayload($relatedModel::class, $attributes->get($relationName))
+                );
+
+                continue;
+            }
+
+            $instance->setRelation($relationName, $relatedModel->newCollection(
+                Collection::make($attributes->get($relationName) ?? [])
+                    ->map(fn (array $data) => static::fromPayload($relatedModel::class, $data))
+                    ->filter()
+                    ->all()
+            ));
+        }
+
+        return $instance;
+    }
+
+    protected static function mapAttributeKeyToTemporal(string $attribute): string
+    {
+        return match (config('temporal.integrations.eloquent.serialize_attribute_case')) {
+            'snake' => Str::snake($attribute),
+            'camel' => Str::camel($attribute),
+            default => $attribute,
+        };
+    }
+
+    protected static function mapAttributeKeyFromTemporal(string $attribute): string
+    {
+        return match (config('temporal.integrations.eloquent.deserialize_attribute_case')) {
+            'snake' => Str::snake($attribute),
+            'camel' => Str::camel($attribute),
+            default => $attribute,
+        };
+    }
+
+    protected static function shouldIncludeMetadataFields(): bool
+    {
+        return config('temporal.integrations.eloquent.include_metadata_field', false);
+    }
+
+    protected static function getModelRelationMethods(Model $model): array
+    {
+        if (isset(static::$modelsRelationsMap[$model::class])) {
+            return static::$modelsRelationsMap[$model::class];
+        }
+
+        $reflectionClass = new \ReflectionClass($model);
+
+        $relations = collect($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC))
+            ->filter(function (\ReflectionMethod $reflectionMethod): bool {
+                $returnType = $reflectionMethod->getReturnType();
+
+                return $returnType instanceof \ReflectionNamedType
+                    && is_subclass_of($returnType->getName(), Relation::class);
+            })
+            ->map(fn (\ReflectionMethod $reflectionMethod) => $reflectionMethod->getName())
+            ->values()
+            ->all();
+
+        return static::$modelsRelationsMap[$model::class] = $relations;
+    }
+}

--- a/tests/Fixtures/Converter/BaseModel.php
+++ b/tests/Fixtures/Converter/BaseModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BaseModel extends Model
+{
+    protected $guarded = [];
+}

--- a/tests/Fixtures/Converter/BaseModel.php
+++ b/tests/Fixtures/Converter/BaseModel.php
@@ -3,8 +3,14 @@
 namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class BaseModel extends Model
 {
     protected $guarded = [];
+
+    public function related(): HasMany
+    {
+        return $this->hasMany(BaseRelatedModel::class);
+    }
 }

--- a/tests/Fixtures/Converter/BaseRelatedModel.php
+++ b/tests/Fixtures/Converter/BaseRelatedModel.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BaseRelatedModel extends Model
+{
+    protected $guarded = [];
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(BaseModel::class);
+    }
+}

--- a/tests/Fixtures/Converter/SampleRelatedModel.php
+++ b/tests/Fixtures/Converter/SampleRelatedModel.php
@@ -3,18 +3,18 @@
 namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 use Keepsuit\LaravelTemporal\Integrations\Eloquent\TemporalEloquentSerialize;
 
-class SampleModel extends Model implements TemporalSerializable
+class SampleRelatedModel extends Model implements TemporalSerializable
 {
     use TemporalEloquentSerialize;
 
     protected $guarded = [];
 
-    public function related(): HasMany
+    public function owner(): BelongsTo
     {
-        return $this->hasMany(SampleRelatedModel::class);
+        return $this->belongsTo(SampleModel::class);
     }
 }

--- a/tests/Fixtures/Converter/TemporalSerializableModel.php
+++ b/tests/Fixtures/Converter/TemporalSerializableModel.php
@@ -3,18 +3,18 @@
 namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 use Keepsuit\LaravelTemporal\Integrations\Eloquent\TemporalEloquentSerialize;
 
-class SampleRelatedModel extends Model implements TemporalSerializable
+class TemporalSerializableModel extends Model implements TemporalSerializable
 {
     use TemporalEloquentSerialize;
 
     protected $guarded = [];
 
-    public function owner(): BelongsTo
+    public function related(): HasMany
     {
-        return $this->belongsTo(SampleModel::class);
+        return $this->hasMany(TemporalSerializableRelatedModel::class);
     }
 }

--- a/tests/Fixtures/Converter/TemporalSerializableRelatedModel.php
+++ b/tests/Fixtures/Converter/TemporalSerializableRelatedModel.php
@@ -3,18 +3,18 @@
 namespace Keepsuit\LaravelTemporal\Tests\Fixtures\Converter;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 use Keepsuit\LaravelTemporal\Integrations\Eloquent\TemporalEloquentSerialize;
 
-class SampleModel extends Model implements TemporalSerializable
+class TemporalSerializableRelatedModel extends Model implements TemporalSerializable
 {
     use TemporalEloquentSerialize;
 
     protected $guarded = [];
 
-    public function related(): HasMany
+    public function owner(): BelongsTo
     {
-        return $this->hasMany(SampleRelatedModel::class);
+        return $this->belongsTo(TemporalSerializableModel::class);
     }
 }

--- a/tests/Integrations/Eloquent/EloquentIntegrationTest.php
+++ b/tests/Integrations/Eloquent/EloquentIntegrationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use Keepsuit\LaravelTemporal\DataConverter\LaravelPayloadConverter;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\SampleModel;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\SampleRelatedModel;
+
+it('can serialize Eloquent model', function () {
+    $model = new SampleModel(['id' => 123]);
+
+    $converter = new LaravelPayloadConverter;
+
+    $payload = $converter->toPayload($model);
+
+    expect($payload->getData())->toBe(json_encode(['id' => 123], LaravelPayloadConverter::JSON_FLAGS));
+});
+
+it('can serialize Eloquent model with relations', function () {
+    $model = new SampleModel(['id' => 123]);
+    $model->setRelation('related', new \Illuminate\Database\Eloquent\Collection([new SampleRelatedModel(['id' => 456])]));
+
+    $converter = new LaravelPayloadConverter;
+
+    $payload = $converter->toPayload($model);
+
+    expect($payload->getData())->toBe(json_encode([
+        'id' => 123,
+        'related' => [
+            ['id' => 456],
+        ],
+    ], LaravelPayloadConverter::JSON_FLAGS));
+});
+
+it('can unserialize Eloquent model', function () {
+    $converter = new LaravelPayloadConverter;
+
+    $payload = (new \Temporal\Api\Common\V1\Payload)
+        ->setData(json_encode(['id' => 123], LaravelPayloadConverter::JSON_FLAGS));
+
+    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(SampleModel::class));
+
+    expect($data)
+        ->toBeInstanceOf(SampleModel::class)
+        ->id->toBe(123);
+});
+
+it('can unserialize Eloquent model with relations', function () {
+    $converter = new LaravelPayloadConverter;
+
+    $payload = (new \Temporal\Api\Common\V1\Payload)
+        ->setData(json_encode([
+            'id' => 123,
+            'related' => [
+                ['id' => 456],
+            ],
+        ], LaravelPayloadConverter::JSON_FLAGS));
+
+    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(SampleModel::class));
+
+    expect($data)
+        ->toBeInstanceOf(SampleModel::class)
+        ->id->toBe(123)
+        ->relationLoaded('related')->toBeTrue()
+        ->related->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class)
+        ->related->first()->toBeInstanceOf(SampleRelatedModel::class)
+        ->related->first()->id->toBe(456);
+});

--- a/tests/Integrations/Eloquent/EloquentIntegrationTest.php
+++ b/tests/Integrations/Eloquent/EloquentIntegrationTest.php
@@ -1,11 +1,11 @@
 <?php
 
 use Keepsuit\LaravelTemporal\DataConverter\LaravelPayloadConverter;
-use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\SampleModel;
-use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\SampleRelatedModel;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\TemporalSerializableModel;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\TemporalSerializableRelatedModel;
 
 it('can serialize Eloquent model', function () {
-    $model = new SampleModel(['id' => 123]);
+    $model = new TemporalSerializableModel(['id' => 123]);
 
     $converter = new LaravelPayloadConverter;
 
@@ -15,8 +15,8 @@ it('can serialize Eloquent model', function () {
 });
 
 it('can serialize Eloquent model with relations', function () {
-    $model = new SampleModel(['id' => 123]);
-    $model->setRelation('related', new \Illuminate\Database\Eloquent\Collection([new SampleRelatedModel(['id' => 456])]));
+    $model = new TemporalSerializableModel(['id' => 123]);
+    $model->setRelation('related', new \Illuminate\Database\Eloquent\Collection([new TemporalSerializableRelatedModel(['id' => 456])]));
 
     $converter = new LaravelPayloadConverter;
 
@@ -36,10 +36,10 @@ it('can unserialize Eloquent model', function () {
     $payload = (new \Temporal\Api\Common\V1\Payload)
         ->setData(json_encode(['id' => 123], LaravelPayloadConverter::JSON_FLAGS));
 
-    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(SampleModel::class));
+    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(TemporalSerializableModel::class));
 
     expect($data)
-        ->toBeInstanceOf(SampleModel::class)
+        ->toBeInstanceOf(TemporalSerializableModel::class)
         ->id->toBe(123);
 });
 
@@ -54,13 +54,13 @@ it('can unserialize Eloquent model with relations', function () {
             ],
         ], LaravelPayloadConverter::JSON_FLAGS));
 
-    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(SampleModel::class));
+    $data = $converter->fromPayload($payload, new \Temporal\DataConverter\Type(TemporalSerializableModel::class));
 
     expect($data)
-        ->toBeInstanceOf(SampleModel::class)
+        ->toBeInstanceOf(TemporalSerializableModel::class)
         ->id->toBe(123)
         ->relationLoaded('related')->toBeTrue()
         ->related->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class)
-        ->related->first()->toBeInstanceOf(SampleRelatedModel::class)
+        ->related->first()->toBeInstanceOf(TemporalSerializableRelatedModel::class)
         ->related->first()->id->toBe(456);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -16,6 +16,7 @@ use Temporal\Workflow\ScopedContextInterface;
 
 uses(TestCase::class)->in(__DIR__.'/Unit');
 uses(TestCase::class)->in(__DIR__.'/Integrations/Temporal');
+uses(TestCase::class)->in(__DIR__.'/Integrations/Eloquent');
 uses(LaravelDataTestCase::class)->in(__DIR__.'/Integrations/LaravelData');
 
 /**

--- a/tests/Unit/LaravelPayloadConverterTest.php
+++ b/tests/Unit/LaravelPayloadConverterTest.php
@@ -3,8 +3,8 @@
 use Illuminate\Database\Eloquent\Model;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 use Keepsuit\LaravelTemporal\DataConverter\LaravelPayloadConverter;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\BaseModel;
 use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\EnumItem;
-use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\SampleModel;
 use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\TemporalSerializableItem;
 use Temporal\DataConverter\Type;
 
@@ -17,7 +17,7 @@ it('can serialize values', function ($value, mixed $result) {
 })->with([
     TemporalSerializable::class => [new TemporalSerializableItem(123), ['type' => TemporalSerializable::class, 'id' => 123]],
     BackedEnum::class => [EnumItem::A, 'a'],
-    Model::class => [new SampleModel(['id' => 123]), ['id' => 123]],
+    Model::class => [new BaseModel(['id' => 123]), ['id' => 123]],
 ]);
 
 it('can deserialize values', function ($input, $type) {
@@ -32,5 +32,5 @@ it('can deserialize values', function ($input, $type) {
     'native type' => [123, new Type(Type::TYPE_INT)],
     TemporalSerializable::class => [new TemporalSerializableItem(123), new Type(TemporalSerializableItem::class)],
     BackedEnum::class => [EnumItem::A, new Type(EnumItem::class)],
-    Model::class => [new SampleModel(['id' => 123]), new Type(SampleModel::class)],
+    Model::class => [new BaseModel(['id' => 123]), new Type(BaseModel::class)],
 ]);

--- a/tests/Unit/LaravelPayloadConverterTest.php
+++ b/tests/Unit/LaravelPayloadConverterTest.php
@@ -1,9 +1,10 @@
 <?php
 
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Keepsuit\LaravelTemporal\Contracts\TemporalSerializable;
 use Keepsuit\LaravelTemporal\DataConverter\LaravelPayloadConverter;
 use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\BaseModel;
+use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\BaseRelatedModel;
 use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\EnumItem;
 use Keepsuit\LaravelTemporal\Tests\Fixtures\Converter\TemporalSerializableItem;
 use Temporal\DataConverter\Type;
@@ -15,9 +16,21 @@ it('can serialize values', function ($value, mixed $result) {
 
     expect($payload->getData())->toBe(json_encode($result, LaravelPayloadConverter::JSON_FLAGS));
 })->with([
-    TemporalSerializable::class => [new TemporalSerializableItem(123), ['type' => TemporalSerializable::class, 'id' => 123]],
-    BackedEnum::class => [EnumItem::A, 'a'],
-    Model::class => [new BaseModel(['id' => 123]), ['id' => 123]],
+    'temporal serializable' => fn () => [
+        new TemporalSerializableItem(123),
+        ['type' => TemporalSerializable::class, 'id' => 123],
+    ],
+    'enum' => fn () => [EnumItem::A, 'a'],
+    'model' => fn () => [
+        (new BaseModel)->newInstance(['id' => 123]),
+        ['id' => 123],
+    ],
+    'model with relations' => fn () => [
+        (new BaseModel)
+            ->newInstance(['id' => 123])
+            ->setRelation('related', Collection::make([(new BaseRelatedModel)->newInstance(['id' => 456])])),
+        ['id' => 123, 'related' => [['id' => 456]]],
+    ],
 ]);
 
 it('can deserialize values', function ($input, $type) {
@@ -29,8 +42,20 @@ it('can deserialize values', function ($input, $type) {
 
     expect($data)->toEqual($input);
 })->with([
-    'native type' => [123, new Type(Type::TYPE_INT)],
-    TemporalSerializable::class => [new TemporalSerializableItem(123), new Type(TemporalSerializableItem::class)],
-    BackedEnum::class => [EnumItem::A, new Type(EnumItem::class)],
-    Model::class => [new BaseModel(['id' => 123]), new Type(BaseModel::class)],
+    'native type' => fn () => [123, new Type(Type::TYPE_INT)],
+    'temporal serializable' => fn () => [
+        new TemporalSerializableItem(123),
+        new Type(TemporalSerializableItem::class),
+    ],
+    'enum' => fn () => [EnumItem::A, new Type(EnumItem::class)],
+    'model' => fn () => [
+        (new BaseModel)->newInstance(['id' => 123], true),
+        new Type(BaseModel::class),
+    ],
+    'model with relations' => fn () => [
+        (new BaseModel)
+            ->newInstance(['id' => 123], true)
+            ->setRelation('related', Collection::make([(new BaseRelatedModel)->newInstance(['id' => 456], true)])),
+        new Type(BaseModel::class),
+    ],
 ]);


### PR DESCRIPTION
Fix #49 

This PR changes how eloquent models relations are detected (`isRelation` method wasn't reliable) and enable eloquent models serialization (without needing to add `TemporalSerializable` interface and `TemporalEloquentSerialize` trait to models