### PR TITLE
fix: unable to use php binary with space in the path

### DIFF
--- a/src/Commands/WorkCommand.php
+++ b/src/Commands/WorkCommand.php
@@ -56,7 +56,7 @@ class WorkCommand extends Command
             $roadRunnerBinary,
             ...['-c', $this->configPath()],
             ...['-o', sprintf('version=%s', $configVersion)],
-            ...['-o', sprintf('server.command=%s ./vendor/bin/roadrunner-temporal-worker', (new PhpExecutableFinder)->find())],
+            ...['-o', sprintf('server.command=%s,./vendor/bin/roadrunner-temporal-worker', (new PhpExecutableFinder)->find())],
             ...['-o', sprintf('temporal.address=%s', config('temporal.address'))],
             ...['-o', sprintf('temporal.namespace=%s', config('temporal.namespace'))],
             ...(is_string($clientKey) && is_string($clientCert))


### PR DESCRIPTION
Fixes an issue if the PHP Binary path has a space in it the worker can't be started.

The following issue is where I took this solution from.

https://github.com/roadrunner-server/roadrunner/issues/1667#issuecomment-1697040985