### PR TITLE
fix: unable to use php binary with space in the path TemporalTestingWorker

### DIFF
--- a/src/Testing/TemporalTestingWorker.php
+++ b/src/Testing/TemporalTestingWorker.php
@@ -72,7 +72,7 @@ class TemporalTestingWorker
             command: [
                 $this->roadRunnerBinary->binaryPath(),
                 ...['-o', sprintf('version=%s', $this->roadRunnerBinary->configVersion())],
-                ...['-o', sprintf('server.command=%s %s', (new PhpExecutableFinder)->find(), $this->findWorkerPath())],
+                ...['-o', sprintf('server.command=%s,%s', (new PhpExecutableFinder)->find(), $this->findWorkerPath())],
                 ...['-o', sprintf('temporal.address=%s', config('temporal.address'))],
                 ...['-o', sprintf('temporal.namespace=%s', config('temporal.namespace'))],
                 ...(is_string($clientKey) && is_string($clientCert))


### PR DESCRIPTION
Same fixed as #62 but for TemporalTestingWorker as well